### PR TITLE
Fix mobile horizontal overscroll

### DIFF
--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -181,10 +181,9 @@
   html {
     -webkit-tap-highlight-color: transparent;
     scroll-behavior: smooth;
-    /* Full-bleed elements (e.g. TopoField's w-screen breakout) run past the
-       visible viewport by a scrollbar's width; clip it here rather than in
-       every element that needs to escape the centred layout. */
+    /* Keep touch panning from revealing full-bleed decoration beyond the page. */
     overflow-x: hidden;
+    overscroll-behavior-x: none;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -203,6 +202,8 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     font-feature-settings: 'cv11', 'ss01';
+    /* Mobile browsers can pan the body independently of the root element. */
+    overflow-x: hidden;
     overflow-wrap: break-word;
   }
 


### PR DESCRIPTION
## What changed

- Clip horizontal overflow on both the root element and body.
- Disable horizontal boundary overscroll on the root element.

## Why

The oversized decorative hero wash extends beyond the viewport. Desktop browsers respected clipping on `html`, but touch browsers could pan the independently scrollable body and reveal the off-canvas decoration.

This keeps the full-bleed visual treatment while preventing touch-only horizontal page movement.

## Validation

- Reproduced and tested at a 363 × 747 mobile viewport.
- Root scroll width decreased from 503px to the 363px viewport width.
- `npm run typecheck`
