### PR TITLE
Revert dark page canvas color

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,17 +12,6 @@
     <meta name="google-site-verification" content="9_Bt8QeiOBOtINDNrvFF99KClO3pDlbTHJ0SPL9Gc5o" />
     <meta name="theme-color" content="#fbfaf7" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#100f0d" media="(prefers-color-scheme: dark)" />
-    <style>
-      html,
-      body {
-        background: #fbfaf7;
-      }
-
-      html[data-theme='dark'],
-      html[data-theme='dark'] body {
-        background: #100f0d;
-      }
-    </style>
 
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />


### PR DESCRIPTION
The dark canvas change from PR #52 caused a hero regression. This reverts that merged change and restores the prior `client/index.html` behavior.

Validation: `git diff --check`.