### PR TITLE
Add synchronized live Jukebox playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ cd ../client && npm install
 
 #### `client/.env`
 
-| Name              | Type   | Recommended value       |  Description              |
-|-------------------|--------|-------------------------|---------------------------|
-| VITE_BACKEND_URL  | string | http://localhost:3000   | URL to the backend server |
+| Name              | Type   | Recommended value                 | Description                                      |
+|-------------------|--------|-----------------------------------|--------------------------------------------------|
+| VITE_BACKEND_URL  | string | http://localhost:3000             | URL to the backend server                        |
+| VITE_JUKEBOX_URL  | string | https://jukebox.wohlbruck.dev     | URL for the opt-in now-playing audio stream     |
 
 Leave `VITE_BACKEND_URL` unset and the live sections (now playing, photos,
 availability, contact form) fall back to a quiet offline state instead of

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { useIntervalFn } from '@vueuse/core'
-import { VolumeX } from '@lucide/vue'
+import { LoaderCircle, VolumeX } from '@lucide/vue'
 import InlineIcon from '@/components/ui/InlineIcon.vue'
 import RecordSleeve from '@/components/social/RecordSleeve.vue'
 import { useLiveStore } from '@/stores/live'
@@ -97,8 +97,14 @@ async function toggleAudio() {
       <button
         type="button"
         class="group relative shrink-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent disabled:cursor-default"
-        :disabled="!streamUrl || live.spotifyAudioPlaying"
-        :aria-label="live.spotifyAudioPlaying ? 'Live playback is unmuted' : 'Unmute live playback'"
+        :disabled="!streamUrl || live.spotifyAudioPlaying || live.spotifyAudioStatus === 'loading'"
+        :aria-label="
+          live.spotifyAudioPlaying
+            ? 'Live playback is unmuted'
+            : live.spotifyAudioStatus === 'loading'
+              ? 'Loading live playback'
+              : 'Unmute live playback'
+        "
         :aria-pressed="live.spotifyAudioPlaying"
         @click="toggleAudio"
       >
@@ -127,7 +133,8 @@ async function toggleAudio() {
           class="absolute -right-1 -top-1 grid size-6 place-items-center rounded-full border border-rule bg-paper text-ink-2 shadow-sm transition-colors group-hover:border-accent group-hover:text-accent"
           aria-hidden="true"
         >
-          <VolumeX class="size-3.5" />
+          <LoaderCircle v-if="live.spotifyAudioStatus === 'loading'" class="size-3.5 animate-spin" />
+          <VolumeX v-else class="size-3.5" />
         </span>
       </button>
 

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -54,12 +54,23 @@ const streamUrl = computed(() => {
   return url.href
 })
 
+function syncedStreamUrl() {
+  if (!streamUrl.value) return null
+  const url = new URL(streamUrl.value)
+  // Jukebox starts its live transcode at this offset. Clamp just below the end
+  // so a timestamp collected as the song finishes does not request past it.
+  const offset = Math.min(Math.max(0, progress.value), Math.max(0, (track.value?.duration_ms ?? 1) - 1))
+  url.searchParams.set('startMs', String(Math.round(offset)))
+  return url.href
+}
+
 async function startAudio() {
-  if (!audio.value || !streamUrl.value) return
+  const url = syncedStreamUrl()
+  if (!audio.value || !url) return
 
   audioError.value = false
   audible.value = true
-  audio.value.src = streamUrl.value
+  audio.value.src = url
   audio.value.load()
 
   try {

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { useIntervalFn } from '@vueuse/core'
+import { Volume2, VolumeX } from '@lucide/vue'
 import InlineIcon from '@/components/ui/InlineIcon.vue'
 import RecordSleeve from '@/components/social/RecordSleeve.vue'
 import { useLiveStore } from '@/stores/live'
-import { JUKEBOX_URL, links } from '@/data/site'
+import { links } from '@/data/site'
 import { formatDuration, relativeTime } from '@/lib/format'
 
 withDefaults(defineProps<{ compact?: boolean }>(), { compact: false })
@@ -41,68 +42,14 @@ const status = computed(() => {
   return playing.value ? 'Listening now' : `Last played ${relativeTime(live.spotify.timestamp)}`
 })
 
-/** Audio must begin from a click. Apart from satisfying browser autoplay rules,
- * it avoids opening a Jukebox transcode for visitors who only want the title. */
-const audio = ref<HTMLAudioElement>()
-const audible = ref(false)
-const audioError = ref(false)
-
 const streamUrl = computed(() => {
-  if (!track.value?.id) return null
-  const url = new URL('/v1/stream', JUKEBOX_URL)
-  url.searchParams.set('spotifyTrackId', track.value.id)
-  return url.href
+  return Boolean(track.value?.id && playing.value)
 })
-
-function syncedStreamUrl() {
-  if (!streamUrl.value) return null
-  const url = new URL(streamUrl.value)
-  // Jukebox starts its live transcode at this offset. Clamp just below the end
-  // so a timestamp collected as the song finishes does not request past it.
-  const offset = Math.min(Math.max(0, progress.value), Math.max(0, (track.value?.duration_ms ?? 1) - 1))
-  url.searchParams.set('startMs', String(Math.round(offset)))
-  return url.href
-}
-
-async function startAudio() {
-  const url = syncedStreamUrl()
-  if (!audio.value || !url) return
-
-  audioError.value = false
-  audible.value = true
-  audio.value.src = url
-  audio.value.load()
-
-  try {
-    await audio.value.play()
-  } catch {
-    audible.value = false
-    audioError.value = true
-  }
-}
-
-function stopAudio() {
-  audible.value = false
-  audio.value?.pause()
-  if (audio.value) audio.value.removeAttribute('src')
-}
 
 async function toggleAudio() {
-  if (audible.value) stopAudio()
-  else await startAudio()
+  if (live.spotifyAudioPlaying) live.stopSpotifyAudio()
+  else await live.startSpotifyAudio(progress.value)
 }
-
-watch(streamUrl, async (next, previous) => {
-  if (!audible.value || !playing.value || !next || next === previous) return
-  await startAudio()
-})
-
-watch(playing, (isPlaying) => {
-  // Do not keep an old stream audible after Spotify itself has stopped.
-  if (audible.value && !isPlaying) stopAudio()
-})
-
-onBeforeUnmount(stopAudio)
 </script>
 
 <template>
@@ -148,11 +95,13 @@ onBeforeUnmount(stopAudio)
         compact && 'w-full',
       ]"
     >
-      <a
-        :href="track.external_urls.spotify"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="shrink-0"
+      <button
+        type="button"
+        class="group relative shrink-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent disabled:cursor-not-allowed"
+        :disabled="!streamUrl"
+        :aria-label="live.spotifyAudioPlaying ? 'Mute live playback' : 'Unmute live playback'"
+        :aria-pressed="live.spotifyAudioPlaying"
+        @click="toggleAudio"
       >
         <RecordSleeve
           :artwork="artwork"
@@ -174,7 +123,15 @@ onBeforeUnmount(stopAudio)
             />
           </span>
         </RecordSleeve>
-      </a>
+        <span
+          class="absolute -right-1 -top-1 grid size-6 place-items-center rounded-full border border-rule bg-paper text-ink-2 shadow-sm transition-colors group-hover:border-accent group-hover:text-accent"
+          :class="live.spotifyAudioPlaying && 'border-accent bg-accent text-paper'"
+          aria-hidden="true"
+        >
+          <VolumeX v-if="live.spotifyAudioPlaying" class="size-3.5" />
+          <Volume2 v-else class="size-3.5" />
+        </span>
+      </button>
 
       <div class="min-w-0 flex-1" :class="compact && 'text-right'">
         <a
@@ -202,20 +159,9 @@ onBeforeUnmount(stopAudio)
       </div>
     </div>
 
-    <div v-if="track" class="mt-3 flex items-center gap-2">
-      <audio ref="audio" preload="none" @error="audioError = true; audible = false" />
-      <button
-        type="button"
-        class="rounded-full border border-ink-3/25 px-3 py-1.5 text-xs font-medium text-ink-2 transition-colors hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
-        :disabled="!streamUrl || !playing"
-        :aria-pressed="audible"
-        @click="toggleAudio"
-      >
-        {{ audible ? 'Mute live playback' : 'Unmute live playback' }}
-      </button>
-      <span v-if="audioError" class="text-xs text-ink-3">Playback is unavailable right now.</span>
-      <span v-else-if="!playing" class="text-xs text-ink-3">Playback resumes when the music does.</span>
-    </div>
+    <p v-if="track && live.spotifyAudioStatus === 'error'" class="mt-3 text-xs text-ink-3">
+      Playback is unavailable right now.
+    </p>
 
     <p v-if="!compact && track" class="mt-3 text-xs text-ink-3">{{ status }}</p>
   </div>

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { useIntervalFn } from '@vueuse/core'
-import { Volume2, VolumeX } from '@lucide/vue'
+import { VolumeX } from '@lucide/vue'
 import InlineIcon from '@/components/ui/InlineIcon.vue'
 import RecordSleeve from '@/components/social/RecordSleeve.vue'
 import { useLiveStore } from '@/stores/live'
@@ -123,12 +123,11 @@ async function toggleAudio() {
           </span>
         </RecordSleeve>
         <span
+          v-if="!live.spotifyAudioPlaying"
           class="absolute -right-1 -top-1 grid size-6 place-items-center rounded-full border border-rule bg-paper text-ink-2 shadow-sm transition-colors group-hover:border-accent group-hover:text-accent"
-          :class="live.spotifyAudioPlaying && 'border-accent bg-accent text-paper'"
           aria-hidden="true"
         >
-          <Volume2 v-if="live.spotifyAudioPlaying" class="size-3.5" />
-          <VolumeX v-else class="size-3.5" />
+          <VolumeX class="size-3.5" />
         </span>
       </button>
 

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -47,8 +47,7 @@ const streamUrl = computed(() => {
 })
 
 async function toggleAudio() {
-  if (live.spotifyAudioPlaying) live.stopSpotifyAudio()
-  else await live.startSpotifyAudio(progress.value)
+  if (!live.spotifyAudioPlaying) await live.startSpotifyAudio(progress.value)
 }
 </script>
 
@@ -97,9 +96,9 @@ async function toggleAudio() {
     >
       <button
         type="button"
-        class="group relative shrink-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent disabled:cursor-not-allowed"
-        :disabled="!streamUrl"
-        :aria-label="live.spotifyAudioPlaying ? 'Mute live playback' : 'Unmute live playback'"
+        class="group relative shrink-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent disabled:cursor-default"
+        :disabled="!streamUrl || live.spotifyAudioPlaying"
+        :aria-label="live.spotifyAudioPlaying ? 'Live playback is unmuted' : 'Unmute live playback'"
         :aria-pressed="live.spotifyAudioPlaying"
         @click="toggleAudio"
       >
@@ -128,8 +127,8 @@ async function toggleAudio() {
           :class="live.spotifyAudioPlaying && 'border-accent bg-accent text-paper'"
           aria-hidden="true"
         >
-          <VolumeX v-if="live.spotifyAudioPlaying" class="size-3.5" />
-          <Volume2 v-else class="size-3.5" />
+          <Volume2 v-if="live.spotifyAudioPlaying" class="size-3.5" />
+          <VolumeX v-else class="size-3.5" />
         </span>
       </button>
 

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -4,7 +4,7 @@ import { useIntervalFn } from '@vueuse/core'
 import InlineIcon from '@/components/ui/InlineIcon.vue'
 import RecordSleeve from '@/components/social/RecordSleeve.vue'
 import { useLiveStore } from '@/stores/live'
-import { links } from '@/data/site'
+import { JUKEBOX_URL, links } from '@/data/site'
 import { formatDuration, relativeTime } from '@/lib/format'
 
 withDefaults(defineProps<{ compact?: boolean }>(), { compact: false })
@@ -40,6 +40,58 @@ const status = computed(() => {
   if (!live.spotify) return 'Listening'
   return playing.value ? 'Listening now' : `Last played ${relativeTime(live.spotify.timestamp)}`
 })
+
+/** Audio must begin from a click. Apart from satisfying browser autoplay rules,
+ * it avoids opening a Jukebox transcode for visitors who only want the title. */
+const audio = ref<HTMLAudioElement>()
+const audible = ref(false)
+const audioError = ref(false)
+
+const streamUrl = computed(() => {
+  if (!track.value?.id) return null
+  const url = new URL('/v1/stream', JUKEBOX_URL)
+  url.searchParams.set('spotifyTrackId', track.value.id)
+  return url.href
+})
+
+async function startAudio() {
+  if (!audio.value || !streamUrl.value) return
+
+  audioError.value = false
+  audible.value = true
+  audio.value.src = streamUrl.value
+  audio.value.load()
+
+  try {
+    await audio.value.play()
+  } catch {
+    audible.value = false
+    audioError.value = true
+  }
+}
+
+function stopAudio() {
+  audible.value = false
+  audio.value?.pause()
+  if (audio.value) audio.value.removeAttribute('src')
+}
+
+async function toggleAudio() {
+  if (audible.value) stopAudio()
+  else await startAudio()
+}
+
+watch(streamUrl, async (next, previous) => {
+  if (!audible.value || !playing.value || !next || next === previous) return
+  await startAudio()
+})
+
+watch(playing, (isPlaying) => {
+  // Do not keep an old stream audible after Spotify itself has stopped.
+  if (audible.value && !isPlaying) stopAudio()
+})
+
+onBeforeUnmount(stopAudio)
 </script>
 
 <template>
@@ -137,6 +189,21 @@ const status = computed(() => {
           </span>
         </div>
       </div>
+    </div>
+
+    <div v-if="track" class="mt-3 flex items-center gap-2">
+      <audio ref="audio" preload="none" @error="audioError = true; audible = false" />
+      <button
+        type="button"
+        class="rounded-full border border-ink-3/25 px-3 py-1.5 text-xs font-medium text-ink-2 transition-colors hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="!streamUrl || !playing"
+        :aria-pressed="audible"
+        @click="toggleAudio"
+      >
+        {{ audible ? 'Mute live playback' : 'Unmute live playback' }}
+      </button>
+      <span v-if="audioError" class="text-xs text-ink-3">Playback is unavailable right now.</span>
+      <span v-else-if="!playing" class="text-xs text-ink-3">Playback resumes when the music does.</span>
     </div>
 
     <p v-if="!compact && track" class="mt-3 text-xs text-ink-3">{{ status }}</p>

--- a/client/src/data/projects.ts
+++ b/client/src/data/projects.ts
@@ -315,7 +315,7 @@ export const projects: Project[] = [
     description:
       'This app lets you stream music from your Spotify account for free by streaming the isolated audio from the Youtube-equivalent music videos. You can search and play songs from Spotify, and the mp3 file will be streamed to the browser. I started to redesign the site with a better user interface and synchonized group playback, but I later scrapped it to work on other projects. There are some concept UI mockups in the screenshots below.',
     start: new Date('2017-02-10'),
-    url: 'https://jukebox-redux.herokuapp.com/',
+    url: 'https://jukebox.wohlbruck.dev',
     github: 'https://github.com/alexwohlbruck/jukebox',
     images: [
       'original.png',

--- a/client/src/data/site.ts
+++ b/client/src/data/site.ts
@@ -74,3 +74,10 @@ export const socials: SocialLink[] = [
  */
 export const BACKEND_URL =
   import.meta.env.VITE_BACKEND_URL ?? (import.meta.env.DEV ? 'http://localhost:3000' : '/api')
+
+/**
+ * Jukebox resolves the Spotify track identifier supplied by the now-playing
+ * API and returns a live MP3 stream. It is deliberately separate from the
+ * Spotify Web Playback SDK: that SDK cannot play an arbitrary audio source.
+ */
+export const JUKEBOX_URL = import.meta.env.VITE_JUKEBOX_URL ?? 'https://jukebox.wohlbruck.dev'

--- a/client/src/data/timeline.ts
+++ b/client/src/data/timeline.ts
@@ -65,7 +65,7 @@ export const timeline: TimelineEvent[] = [
     title: 'Appalachian State',
     url: 'https://www.appstate.edu/',
     description:
-      'Four years at Appalachian State University, finishing with a B.S. in computer science. Both PunchAlert stints happened while I was enrolled.',
+      'Four years at Appalachian State University, finishing with a B.S. in computer science.',
     icon: 'svg/appstate.svg',
   },
   {

--- a/client/src/data/types.ts
+++ b/client/src/data/types.ts
@@ -73,6 +73,15 @@ export interface SpotifyPlaybackState {
     album: { images: { url: string; width: number; height: number }[] }
     artists: { name: string; external_urls: { spotify: string } }[]
   }
+  /** First item from Spotify's dynamic queue, when available. */
+  next_item?: {
+    id: string
+    name: string
+    duration_ms: number
+    external_urls: { spotify: string }
+    album: { images: { url: string; width: number; height: number }[] }
+    artists: { name: string; external_urls: { spotify: string } }[]
+  } | null
 }
 
 /** A track as it appears in a list rather than in the player. */

--- a/client/src/data/types.ts
+++ b/client/src/data/types.ts
@@ -66,6 +66,7 @@ export interface SpotifyPlaybackState {
   timestamp: number | string
   progress_ms: number
   item: {
+    id: string
     name: string
     duration_ms: number
     external_urls: { spotify: string }

--- a/client/src/stores/live.ts
+++ b/client/src/stores/live.ts
@@ -43,6 +43,7 @@ export const useLiveStore = defineStore('live', () => {
   let polling = false
   /** Kept in the store rather than a card so route changes never stop audio. */
   let spotifyAudio: HTMLAudioElement | undefined
+  let audioRequest = 0
   const spotifyAudioStatus = ref<AudioStatus>('idle')
   const spotifyAudioPlaying = ref(false)
 
@@ -71,15 +72,15 @@ export const useLiveStore = defineStore('live', () => {
     return url.href
   }
 
-  function getSpotifyAudio() {
-    if (spotifyAudio) return spotifyAudio
-    spotifyAudio = new Audio()
-    spotifyAudio.preload = 'none'
-    spotifyAudio.addEventListener('error', () => {
+  function createSpotifyAudio() {
+    const audio = new Audio()
+    audio.preload = 'none'
+    audio.addEventListener('error', () => {
+      if (audio !== spotifyAudio) return
       spotifyAudioPlaying.value = false
       spotifyAudioStatus.value = 'error'
     })
-    return spotifyAudio
+    return audio
   }
 
   async function startSpotifyAudio(progressMs: number) {
@@ -87,21 +88,55 @@ export const useLiveStore = defineStore('live', () => {
     const url = audioStreamUrl(progressMs)
     if (!url) return
 
-    const audio = getSpotifyAudio()
+    const request = ++audioRequest
+    const previous = spotifyAudio
+    const audio = createSpotifyAudio()
     spotifyAudioStatus.value = 'loading'
+    audio.volume = previous ? 0 : 1
     audio.src = url
     audio.load()
     try {
       await audio.play()
+      // A later track change won while this source was resolving.
+      if (request !== audioRequest) {
+        audio.pause()
+        audio.removeAttribute('src')
+        return
+      }
+
+      spotifyAudio = audio
       spotifyAudioPlaying.value = true
       spotifyAudioStatus.value = 'playing'
+      if (previous) crossfade(previous, audio)
     } catch {
+      if (request !== audioRequest) return
       spotifyAudioPlaying.value = false
       spotifyAudioStatus.value = 'error'
     }
   }
 
+  /** Let the new track buffer and start before fading the old one out. */
+  function crossfade(oldAudio: HTMLAudioElement, newAudio: HTMLAudioElement) {
+    const duration = 450
+    const started = performance.now()
+    const oldVolume = oldAudio.volume
+
+    const frame = (now: number) => {
+      const progress = Math.min(1, (now - started) / duration)
+      oldAudio.volume = oldVolume * (1 - progress)
+      newAudio.volume = progress
+      if (progress < 1) requestAnimationFrame(frame)
+      else {
+        oldAudio.pause()
+        oldAudio.removeAttribute('src')
+        oldAudio.load()
+      }
+    }
+    requestAnimationFrame(frame)
+  }
+
   function stopSpotifyAudio() {
+    audioRequest += 1
     spotifyAudioPlaying.value = false
     spotifyAudioStatus.value = 'idle'
     spotifyAudio?.pause()

--- a/client/src/stores/live.ts
+++ b/client/src/stores/live.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
-import { BACKEND_URL } from '@/data/site'
+import { computed, ref, watch } from 'vue'
+import { BACKEND_URL, JUKEBOX_URL } from '@/data/site'
 import type {
   CalendarEvent,
   InstagramImage,
@@ -29,6 +29,7 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 type Status = 'idle' | 'loading' | 'ready' | 'error'
+type AudioStatus = 'idle' | 'loading' | 'playing' | 'error'
 
 /**
  * Everything on the site that comes from the Express server. Each section owns
@@ -40,6 +41,10 @@ export const useLiveStore = defineStore('live', () => {
   let stream: EventSource | undefined
   let spotifyTimer: ReturnType<typeof setTimeout> | undefined
   let polling = false
+  /** Kept in the store rather than a card so route changes never stop audio. */
+  let spotifyAudio: HTMLAudioElement | undefined
+  const spotifyAudioStatus = ref<AudioStatus>('idle')
+  const spotifyAudioPlaying = ref(false)
 
   const listening = ref<SpotifyListening | null>(null)
   const listeningStatus = ref<Status>('idle')
@@ -52,6 +57,73 @@ export const useLiveStore = defineStore('live', () => {
 
   const calendar = ref<CalendarEvent[]>([])
   const calendarStatus = ref<Status>('idle')
+
+  function audioStreamUrl(progressMs: number) {
+    const state = spotify.value
+    if (!state?.item.id) return null
+    const url = new URL('/v1/stream', JUKEBOX_URL)
+    url.searchParams.set('spotifyTrackId', state.item.id)
+    // A finished timestamp is not a playable offset. Jukebox begins the
+    // transcode at this point rather than requiring the browser to seek a
+    // chunked response.
+    const offset = Math.min(Math.max(0, progressMs), Math.max(0, state.item.duration_ms - 1))
+    url.searchParams.set('startMs', String(Math.round(offset)))
+    return url.href
+  }
+
+  function getSpotifyAudio() {
+    if (spotifyAudio) return spotifyAudio
+    spotifyAudio = new Audio()
+    spotifyAudio.preload = 'none'
+    spotifyAudio.addEventListener('error', () => {
+      spotifyAudioPlaying.value = false
+      spotifyAudioStatus.value = 'error'
+    })
+    return spotifyAudio
+  }
+
+  async function startSpotifyAudio(progressMs: number) {
+    if (!spotify.value?.is_playing) return
+    const url = audioStreamUrl(progressMs)
+    if (!url) return
+
+    const audio = getSpotifyAudio()
+    spotifyAudioStatus.value = 'loading'
+    audio.src = url
+    audio.load()
+    try {
+      await audio.play()
+      spotifyAudioPlaying.value = true
+      spotifyAudioStatus.value = 'playing'
+    } catch {
+      spotifyAudioPlaying.value = false
+      spotifyAudioStatus.value = 'error'
+    }
+  }
+
+  function stopSpotifyAudio() {
+    spotifyAudioPlaying.value = false
+    spotifyAudioStatus.value = 'idle'
+    spotifyAudio?.pause()
+    spotifyAudio?.removeAttribute('src')
+    spotifyAudio?.load()
+  }
+
+  watch(
+    () => spotify.value?.item.id,
+    (id, previous) => {
+      if (spotifyAudioPlaying.value && id && id !== previous && spotify.value?.is_playing) {
+        void startSpotifyAudio(spotify.value.progress_ms)
+      }
+    },
+  )
+
+  watch(
+    () => spotify.value?.is_playing,
+    (isPlaying) => {
+      if (spotifyAudioPlaying.value && !isPlaying) stopSpotifyAudio()
+    },
+  )
 
   /**
    * The server holds one connection open and writes the track when it changes,
@@ -255,6 +327,10 @@ export const useLiveStore = defineStore('live', () => {
     spotifyStatus,
     fetchSpotify,
     stopSpotifyPolling,
+    spotifyAudioStatus,
+    spotifyAudioPlaying,
+    startSpotifyAudio,
+    stopSpotifyAudio,
     listening,
     listeningStatus,
     fetchListening,

--- a/client/src/stores/live.ts
+++ b/client/src/stores/live.ts
@@ -142,12 +142,16 @@ export const useLiveStore = defineStore('live', () => {
     spotifyAudio?.pause()
     spotifyAudio?.removeAttribute('src')
     spotifyAudio?.load()
+    spotifyAudio = undefined
   }
 
   watch(
     () => spotify.value?.item.id,
     (id, previous) => {
       if (spotifyAudioPlaying.value && id && id !== previous && spotify.value?.is_playing) {
+        // Never let a stale track play through while the replacement is being
+        // resolved. The incoming source starts from Spotify's live position.
+        stopSpotifyAudio()
         void startSpotifyAudio(spotify.value.progress_ms)
       }
     },

--- a/client/src/stores/live.ts
+++ b/client/src/stores/live.ts
@@ -43,6 +43,8 @@ export const useLiveStore = defineStore('live', () => {
   let polling = false
   /** Kept in the store rather than a card so route changes never stop audio. */
   let spotifyAudio: HTMLAudioElement | undefined
+  let preloadedSpotifyAudio: HTMLAudioElement | undefined
+  let preloadedSpotifyTrackId: string | undefined
   let audioRequest = 0
   const spotifyAudioStatus = ref<AudioStatus>('idle')
   const spotifyAudioPlaying = ref(false)
@@ -59,15 +61,14 @@ export const useLiveStore = defineStore('live', () => {
   const calendar = ref<CalendarEvent[]>([])
   const calendarStatus = ref<Status>('idle')
 
-  function audioStreamUrl(progressMs: number) {
-    const state = spotify.value
-    if (!state?.item.id) return null
+  function audioStreamUrl(progressMs: number, item = spotify.value?.item) {
+    if (!item?.id) return null
     const url = new URL('/v1/stream', JUKEBOX_URL)
-    url.searchParams.set('spotifyTrackId', state.item.id)
+    url.searchParams.set('spotifyTrackId', item.id)
     // A finished timestamp is not a playable offset. Jukebox begins the
     // transcode at this point rather than requiring the browser to seek a
     // chunked response.
-    const offset = Math.min(Math.max(0, progressMs), Math.max(0, state.item.duration_ms - 1))
+    const offset = Math.min(Math.max(0, progressMs), Math.max(0, item.duration_ms - 1))
     url.searchParams.set('startMs', String(Math.round(offset)))
     return url.href
   }
@@ -81,6 +82,33 @@ export const useLiveStore = defineStore('live', () => {
       spotifyAudioStatus.value = 'error'
     })
     return audio
+  }
+
+  function discardPreloadedSpotifyAudio() {
+    preloadedSpotifyAudio?.pause()
+    preloadedSpotifyAudio?.removeAttribute('src')
+    preloadedSpotifyAudio?.load()
+    preloadedSpotifyAudio = undefined
+    preloadedSpotifyTrackId = undefined
+  }
+
+  /** Warm exactly one predicted next track. Preload fetches and decodes audio
+   * without playing it, so the user hears nothing until Spotify switches. */
+  function preloadNextSpotifyAudio() {
+    if (!spotifyAudioPlaying.value) return
+    const next = spotify.value?.next_item
+    if (!next?.id || next.id === spotify.value?.item.id) return discardPreloadedSpotifyAudio()
+    if (preloadedSpotifyTrackId === next.id) return
+
+    discardPreloadedSpotifyAudio()
+    const url = audioStreamUrl(0, next)
+    if (!url) return
+    const audio = createSpotifyAudio()
+    audio.preload = 'auto'
+    audio.src = url
+    audio.load()
+    preloadedSpotifyAudio = audio
+    preloadedSpotifyTrackId = next.id
   }
 
   async function startSpotifyAudio(progressMs: number) {
@@ -108,6 +136,7 @@ export const useLiveStore = defineStore('live', () => {
       spotifyAudioPlaying.value = true
       spotifyAudioStatus.value = 'playing'
       if (previous) crossfade(previous, audio)
+      preloadNextSpotifyAudio()
     } catch {
       if (request !== audioRequest) return
       spotifyAudioPlaying.value = false
@@ -143,18 +172,28 @@ export const useLiveStore = defineStore('live', () => {
     spotifyAudio?.removeAttribute('src')
     spotifyAudio?.load()
     spotifyAudio = undefined
+    discardPreloadedSpotifyAudio()
   }
 
   watch(
     () => spotify.value?.item.id,
     (id, previous) => {
       if (spotifyAudioPlaying.value && id && id !== previous && spotify.value?.is_playing) {
-        // Never let a stale track play through while the replacement is being
-        // resolved. The incoming source starts from Spotify's live position.
-        stopSpotifyAudio()
-        void startSpotifyAudio(spotify.value.progress_ms)
+        if (preloadedSpotifyTrackId === id && preloadedSpotifyAudio && spotifyAudio) {
+          void playPreloadedSpotifyAudio(spotifyAudio, preloadedSpotifyAudio)
+        } else {
+          // A manual skip can bypass Spotify's queue prediction. Do not let a
+          // stale track play through while the replacement is being resolved.
+          stopSpotifyAudio()
+          void startSpotifyAudio(spotify.value.progress_ms)
+        }
       }
     },
+  )
+
+  watch(
+    () => spotify.value?.next_item?.id,
+    () => preloadNextSpotifyAudio(),
   )
 
   watch(
@@ -163,6 +202,26 @@ export const useLiveStore = defineStore('live', () => {
       if (spotifyAudioPlaying.value && !isPlaying) stopSpotifyAudio()
     },
   )
+
+  async function playPreloadedSpotifyAudio(oldAudio: HTMLAudioElement, newAudio: HTMLAudioElement) {
+    const request = ++audioRequest
+    // Take ownership without clearing the source we just spent time buffering.
+    preloadedSpotifyAudio = undefined
+    preloadedSpotifyTrackId = undefined
+    newAudio.volume = 0
+    try {
+      await newAudio.play()
+      if (request !== audioRequest) return
+      spotifyAudio = newAudio
+      spotifyAudioStatus.value = 'playing'
+      crossfade(oldAudio, newAudio)
+      preloadNextSpotifyAudio()
+    } catch {
+      if (request !== audioRequest) return
+      stopSpotifyAudio()
+      void startSpotifyAudio(spotify.value?.progress_ms ?? 0)
+    }
+  }
 
   /**
    * The server holds one connection open and writes the track when it changes,

--- a/server/src/apis/spotify.js
+++ b/server/src/apis/spotify.js
@@ -87,6 +87,7 @@ async function call(path) {
 function shapeTrack(track) {
   if (!track) return null
   return {
+    id: track.id,
     name: track.name,
     duration_ms: track.duration_ms,
     external_urls: { spotify: track.external_urls?.spotify ?? '' },

--- a/server/src/apis/spotify.js
+++ b/server/src/apis/spotify.js
@@ -116,11 +116,13 @@ export async function getPlaybackState() {
     playback?.item && playback.currently_playing_type !== 'episode' && playback.timestamp
 
   if (playingTrack) {
+    const nextItem = await getQueuedTrack()
     return {
       is_playing: Boolean(playback.is_playing),
       timestamp: playback.timestamp,
       progress_ms: playback.progress_ms ?? 0,
       item: shapeTrack(playback.item),
+      next_item: nextItem,
     }
   }
 
@@ -133,6 +135,20 @@ export async function getPlaybackState() {
     timestamp: last.played_at,
     progress_ms: last.track.duration_ms,
     item: shapeTrack(last.track),
+  }
+}
+
+/** The first queued track is a prediction, not a promise: shuffle, manual
+ * skips, and radio can change it. It is enough to warm the next Jukebox stream
+ * while the present one plays. A queue that is unavailable must never break
+ * now-playing, so it stays an optional part of the state. */
+async function getQueuedTrack() {
+  try {
+    const queue = await call('/me/player/queue')
+    const next = queue?.queue?.find((item) => item?.type !== 'episode')
+    return shapeTrack(next)
+  } catch {
+    return null
   }
 }
 

--- a/server/src/lib/now-playing.js
+++ b/server/src/lib/now-playing.js
@@ -20,7 +20,7 @@ import { log } from '../util.js'
 
 /** While a track is playing, never wait longer than this between checks, so a
  *  skip or a pause shows up reasonably soon rather than at the end of the song. */
-const ACTIVE_MAX = 10_000
+const ACTIVE_MAX = 5_000
 const ACTIVE_MIN = 5_000
 /** Nothing playing changes slowly. */
 const IDLE = 60_000

--- a/server/test/now-playing.test.js
+++ b/server/test/now-playing.test.js
@@ -40,6 +40,10 @@ globalThis.fetch = async (url, init) => {
     return json({ items: [{ played_at: '2026-08-11T00:00:00Z', track: makeTrack(track) }] })
   }
 
+  if (href.includes('/me/player/queue')) {
+    return json({ queue: [makeTrack('Next Song', '2up3OPMp9Tb4dAKM2erWXQ')] })
+  }
+
   if (href.includes('/me/player')) {
     playbackCalls += 1
     if (!playing) return new Response(null, { status: 204 })
@@ -59,9 +63,9 @@ globalThis.fetch = async (url, init) => {
  *  its 30s ceiling, so these tests take seconds instead of half a minute. */
 const DURATION = 4_000
 
-function makeTrack(name) {
+function makeTrack(name, id = '4uLU6hMCjMI75M1A2tKUQC') {
   return {
-    id: '4uLU6hMCjMI75M1A2tKUQC',
+    id,
     name,
     duration_ms: DURATION,
     // Fields Spotify has since removed, to prove they do not reach the client.
@@ -126,8 +130,9 @@ describe('now playing', () => {
 
     assert.equal(state.item.name, 'First Song')
     assert.equal(state.item.id, '4uLU6hMCjMI75M1A2tKUQC')
+    assert.equal(state.next_item.name, 'Next Song')
     assert.equal(state.is_playing, true)
-    assert.deepEqual(Object.keys(state).sort(), ['is_playing', 'item', 'progress_ms', 'timestamp'])
+    assert.deepEqual(Object.keys(state).sort(), ['is_playing', 'item', 'next_item', 'progress_ms', 'timestamp'])
     assert.equal(state.item.popularity, undefined)
     assert.equal(state.item.available_markets, undefined)
   })

--- a/server/test/now-playing.test.js
+++ b/server/test/now-playing.test.js
@@ -61,6 +61,7 @@ const DURATION = 4_000
 
 function makeTrack(name) {
   return {
+    id: '4uLU6hMCjMI75M1A2tKUQC',
     name,
     duration_ms: DURATION,
     // Fields Spotify has since removed, to prove they do not reach the client.
@@ -124,6 +125,7 @@ describe('now playing', () => {
     const state = await (await fetch(`${base}/spotify/playback-state`)).json()
 
     assert.equal(state.item.name, 'First Song')
+    assert.equal(state.item.id, '4uLU6hMCjMI75M1A2tKUQC')
     assert.equal(state.is_playing, true)
     assert.deepEqual(Object.keys(state).sort(), ['is_playing', 'item', 'progress_ms', 'timestamp'])
     assert.equal(state.item.popularity, undefined)


### PR DESCRIPTION
## Summary

- add opt-in Jukebox playback to the Spotify now-playing widget
- start streams at Spotify’s reported position and retain audio across navigation
- prebuffer the next queued track for crossfades, with immediate replacement for manual skips
- refine the album-art unmute/loading affordance

## Validation

- `npm run typecheck`
- `npm run build`
- `node --test test/now-playing.test.js`

## Deployment note

Deploy the Jukebox offset-stream support already merged in alexwohlbruck/jukebox before merging this site PR.