### PR TITLE
Refine live playback toolbar control

### DIFF
--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -101,11 +101,11 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group flex h-9 shrink-0 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          class="group flex h-9 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           :class="
             live.spotifyAudioPlaying
               ? 'w-44 gap-2 rounded-lg border border-rule bg-paper-sunk/60 py-1 pl-1 pr-2 shadow-sm hover:border-accent sm:w-56'
-              : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent sm:rounded-none sm:border-transparent sm:bg-transparent sm:shadow-none sm:hover:border-transparent'
+              : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent'
           "
           :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
           :aria-pressed="live.spotifyAudioPlaying"
@@ -129,11 +129,11 @@ function togglePlayback() {
             <span v-else class="block size-7 rounded-[4px] bg-paper" />
           </span>
           <span
-            class="hidden min-w-0 flex-1 transition-[opacity,transform] duration-200 ease-out-quint sm:block"
+            class="hidden min-w-0 transition-[width,opacity,transform] duration-200 ease-out-quint sm:block"
             :class="
               live.spotifyAudioPlaying
-                ? 'translate-x-0 opacity-100 delay-100'
-                : 'pointer-events-none translate-x-1 opacity-0'
+                ? 'flex-1 translate-x-0 opacity-100 delay-100'
+                : 'pointer-events-none w-0 flex-none translate-x-1 opacity-0'
             "
           >
             <span class="block truncate text-xs font-medium">{{ track.name }}</span>

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -122,7 +122,7 @@ function togglePlayback() {
             class="shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out-quint"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-7 translate-x-0 opacity-100 delay-75'
+                ? 'w-9 translate-x-0 opacity-100 delay-75 sm:w-7'
                 : 'w-0 -translate-x-1 opacity-0'
             "
             aria-hidden="true"
@@ -131,9 +131,9 @@ function togglePlayback() {
               v-if="artwork"
               :src="artwork"
               alt=""
-              class="size-7 rounded-[4px] object-cover shadow-sm"
+              class="size-9 object-cover sm:size-7 sm:rounded-[4px] sm:shadow-sm"
             />
-            <span v-else class="block size-7 rounded-[4px] bg-paper" />
+            <span v-else class="block size-9 bg-paper sm:size-7 sm:rounded-[4px]" />
           </span>
           <span
             class="hidden min-w-0 transition-[width,opacity,transform] duration-200 ease-out-quint sm:block"

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -101,24 +101,52 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group flex h-9 max-w-44 items-center gap-2 rounded-lg border border-rule bg-paper-sunk/60 py-1 pl-1 pr-2 text-left shadow-sm transition-colors hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent sm:max-w-56"
+          class="group flex h-9 items-center overflow-hidden rounded-lg border border-rule bg-paper-sunk/60 text-left shadow-sm transition-[width,padding,gap,border-color,background-color] duration-300 ease-out-quint hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          :class="
+            live.spotifyAudioPlaying
+              ? 'w-44 gap-2 py-1 pl-1 pr-2 sm:w-56'
+              : 'w-9 justify-center p-0'
+          "
           :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
           :aria-pressed="live.spotifyAudioPlaying"
           @click="togglePlayback"
         >
-          <img
-            v-if="artwork"
-            :src="artwork"
-            alt=""
-            class="size-7 shrink-0 rounded-[4px] object-cover shadow-sm"
-          />
-          <span v-else class="size-7 shrink-0 rounded-[4px] bg-paper" aria-hidden="true" />
-          <span class="hidden min-w-0 flex-1 sm:block">
+          <span
+            class="shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out-quint"
+            :class="
+              live.spotifyAudioPlaying
+                ? 'w-7 translate-x-0 opacity-100 delay-75'
+                : 'w-0 -translate-x-1 opacity-0'
+            "
+            aria-hidden="true"
+          >
+            <img
+              v-if="artwork"
+              :src="artwork"
+              alt=""
+              class="size-7 rounded-[4px] object-cover shadow-sm"
+            />
+            <span v-else class="block size-7 rounded-[4px] bg-paper" />
+          </span>
+          <span
+            class="hidden min-w-0 flex-1 transition-[opacity,transform] duration-200 ease-out-quint sm:block"
+            :class="
+              live.spotifyAudioPlaying
+                ? 'translate-x-0 opacity-100 delay-100'
+                : 'pointer-events-none translate-x-1 opacity-0'
+            "
+          >
             <span class="block truncate text-xs font-medium">{{ track.name }}</span>
             <span class="block truncate text-[0.65rem] text-ink-3">{{ track.artists[0]?.name }}</span>
           </span>
-          <Volume2 v-if="live.spotifyAudioPlaying" class="size-3.5 shrink-0 text-accent" />
-          <VolumeX v-else class="size-3.5 shrink-0 text-ink-3 group-hover:text-accent" />
+          <Transition name="playback-icon" mode="out-in">
+            <Volume2
+              v-if="live.spotifyAudioPlaying"
+              key="unmuted"
+              class="size-3.5 shrink-0 text-accent"
+            />
+            <VolumeX v-else key="muted" class="size-3.5 shrink-0 text-ink-3 group-hover:text-accent" />
+          </Transition>
         </button>
 
         <ThemeToggle />
@@ -171,3 +199,27 @@ function togglePlayback() {
     </div>
   </header>
 </template>
+
+<style scoped>
+.playback-icon-enter-active,
+.playback-icon-leave-active {
+  transition:
+    opacity 160ms ease-out,
+    transform 200ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 160ms ease-out;
+}
+
+.playback-icon-enter-from,
+.playback-icon-leave-to {
+  opacity: 0;
+  filter: blur(2px);
+  transform: scale(0.72);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .playback-icon-enter-active,
+  .playback-icon-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,11 +119,11 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out-quint"
+            class="playback-artwork shrink-0 overflow-hidden"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-9 translate-x-0 opacity-100 delay-75 sm:w-7'
-                : 'w-0 -translate-x-1 opacity-0'
+                ? 'playback-artwork-visible w-9 sm:w-7'
+                : 'w-0 opacity-0'
             "
             aria-hidden="true"
           >
@@ -232,9 +232,24 @@ function togglePlayback() {
   transform: scale(0.72);
 }
 
+.playback-artwork {
+  clip-path: inset(0 50% round 0.25rem);
+  transition:
+    width 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 180ms ease-out,
+    clip-path 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.playback-artwork-visible {
+  clip-path: inset(0 round 0.25rem);
+  opacity: 1;
+  transition-delay: 0ms, 70ms, 0ms;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .playback-icon-enter-active,
-  .playback-icon-leave-active {
+  .playback-icon-leave-active,
+  .playback-artwork {
     transition: none;
   }
 }

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -105,7 +105,7 @@ function togglePlayback() {
           :class="
             live.spotifyAudioPlaying
               ? 'w-9 justify-center p-0 sm:min-w-36 sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
-              : 'w-9 justify-center p-0'
+              : 'w-9 justify-center gap-0 p-0'
           "
           :disabled="live.spotifyAudioStatus === 'loading'"
           :aria-label="

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -14,7 +14,7 @@ import {
   DialogTrigger,
   VisuallyHidden,
 } from 'reka-ui'
-import { Menu, Volume2, VolumeX, X } from '@lucide/vue'
+import { LoaderCircle, Menu, Volume2, VolumeX, X } from '@lucide/vue'
 import ThemeToggle from './ThemeToggle.vue'
 import { ease } from '@/lib/motion'
 import { site } from '@/data/site'
@@ -107,7 +107,14 @@ function togglePlayback() {
               ? 'w-9 justify-center rounded-md border border-transparent bg-transparent p-0 shadow-none sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
               : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent'
           "
-          :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
+          :disabled="live.spotifyAudioStatus === 'loading'"
+          :aria-label="
+            live.spotifyAudioStatus === 'loading'
+              ? `Loading ${track.name}`
+              : live.spotifyAudioPlaying
+                ? `Mute ${track.name}`
+                : `Unmute ${track.name}`
+          "
           :aria-pressed="live.spotifyAudioPlaying"
           @click="togglePlayback"
         >
@@ -140,8 +147,13 @@ function togglePlayback() {
             <span class="block truncate text-[0.65rem] text-ink-3">{{ track.artists[0]?.name }}</span>
           </span>
           <Transition name="playback-icon" mode="out-in">
+            <LoaderCircle
+              v-if="live.spotifyAudioStatus === 'loading'"
+              key="loading"
+              class="absolute inset-0 z-10 m-auto size-3.5 shrink-0 animate-spin text-ink-3 sm:static sm:m-0"
+            />
             <Volume2
-              v-if="live.spotifyAudioPlaying"
+              v-else-if="live.spotifyAudioPlaying"
               key="unmuted"
               class="absolute inset-0 z-10 m-auto size-3.5 shrink-0 text-paper drop-shadow-[0_1px_2px_rgba(0,0,0,0.72)] sm:static sm:m-0 sm:text-accent sm:drop-shadow-none"
             />

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -101,11 +101,11 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group flex h-9 items-center overflow-hidden rounded-lg border border-rule bg-paper-sunk/60 text-left shadow-sm transition-[width,padding,gap,border-color,background-color] duration-300 ease-out-quint hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          class="group flex h-9 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           :class="
             live.spotifyAudioPlaying
-              ? 'w-44 gap-2 py-1 pl-1 pr-2 sm:w-56'
-              : 'w-9 justify-center p-0'
+              ? 'w-44 gap-2 rounded-lg border border-rule bg-paper-sunk/60 py-1 pl-1 pr-2 shadow-sm hover:border-accent sm:w-56'
+              : 'w-9 justify-center border border-transparent bg-transparent p-0 shadow-none hover:border-transparent'
           "
           :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
           :aria-pressed="live.spotifyAudioPlaying"

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -122,8 +122,8 @@ function togglePlayback() {
             class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-500 ease-out-quint sm:duration-200"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-9 opacity-100 blur-0 sm:w-7 sm:translate-x-0'
-                : 'w-0 opacity-0 blur-[10px] sm:-translate-x-1 sm:blur-0'
+                ? 'w-9 opacity-100 blur-0 md:w-7 md:translate-x-0'
+                : 'w-0 opacity-0 blur-[10px] md:-translate-x-1 md:blur-0'
             "
             aria-hidden="true"
           >

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -101,10 +101,10 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group flex h-9 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          class="group relative flex h-9 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           :class="
             live.spotifyAudioPlaying
-              ? 'w-44 gap-2 rounded-lg border border-rule bg-paper-sunk/60 py-1 pl-1 pr-2 shadow-sm hover:border-accent sm:w-56'
+              ? 'w-9 justify-center rounded-md border border-transparent bg-transparent p-0 shadow-none sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
               : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent'
           "
           :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
@@ -115,7 +115,7 @@ function togglePlayback() {
             class="shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out-quint"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-7 translate-x-0 opacity-100 delay-75'
+                ? 'w-9 translate-x-0 opacity-100 delay-75 sm:w-7'
                 : 'w-0 -translate-x-1 opacity-0'
             "
             aria-hidden="true"
@@ -124,9 +124,9 @@ function togglePlayback() {
               v-if="artwork"
               :src="artwork"
               alt=""
-              class="size-7 rounded-[4px] object-cover shadow-sm"
+              class="size-9 rounded-md object-cover shadow-sm sm:size-7 sm:rounded-[4px]"
             />
-            <span v-else class="block size-7 rounded-[4px] bg-paper" />
+            <span v-else class="block size-9 rounded-md bg-paper sm:size-7 sm:rounded-[4px]" />
           </span>
           <span
             class="hidden min-w-0 transition-[width,opacity,transform] duration-200 ease-out-quint sm:block"
@@ -143,9 +143,13 @@ function togglePlayback() {
             <Volume2
               v-if="live.spotifyAudioPlaying"
               key="unmuted"
-              class="size-3.5 shrink-0 text-accent"
+              class="absolute inset-0 z-10 m-auto size-3.5 shrink-0 text-paper drop-shadow-[0_1px_2px_rgba(0,0,0,0.72)] sm:static sm:m-0 sm:text-accent sm:drop-shadow-none"
             />
-            <VolumeX v-else key="muted" class="size-3.5 shrink-0 text-ink-3 group-hover:text-accent" />
+            <VolumeX
+              v-else
+              key="muted"
+              class="absolute inset-0 z-10 m-auto size-3.5 shrink-0 text-ink-3 group-hover:text-accent sm:static sm:m-0"
+            />
           </Transition>
         </button>
 

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,7 +119,7 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="playback-artwork shrink-0 overflow-hidden transition-[opacity,filter] duration-[5000ms] ease-out-quint md:transition-[width,opacity,transform,filter] md:duration-[2000ms]"
+            class="playback-artwork shrink-0 overflow-hidden transition-[opacity,filter] duration-500 ease-out-quint md:transition-[width,opacity,transform,filter] md:duration-200"
             :class="
               live.spotifyAudioPlaying
                 ? 'w-9 opacity-100 blur-0 md:w-7 md:translate-x-0'
@@ -136,7 +136,7 @@ function togglePlayback() {
             <span v-else class="block size-9 bg-paper sm:size-7 sm:rounded-[4px]" />
           </span>
           <span
-            class="playback-labels hidden min-w-0 transition-[width,opacity,transform,filter] duration-[2000ms] ease-out-quint sm:block"
+            class="playback-labels hidden min-w-0 transition-[width,opacity,transform,filter] duration-200 ease-out-quint sm:block"
             :class="
               live.spotifyAudioPlaying
                 ? 'flex-1 translate-x-0 opacity-100 blur-0 delay-100'

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,11 +119,11 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="playback-artwork shrink-0 overflow-hidden"
+            class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-200 ease-out-quint"
             :class="
               live.spotifyAudioPlaying
-                ? 'playback-artwork-visible w-9 sm:w-7'
-                : 'w-0 opacity-0'
+                ? 'w-9 scale-100 opacity-100 blur-0 delay-75 sm:w-7 sm:translate-x-0'
+                : 'w-0 scale-75 opacity-0 blur-[2px] sm:-translate-x-1 sm:scale-100 sm:blur-0'
             "
             aria-hidden="true"
           >
@@ -232,23 +232,12 @@ function togglePlayback() {
   transform: scale(0.72);
 }
 
-.playback-artwork {
-  clip-path: inset(0 50% round 0.25rem);
-  transition:
-    width 280ms cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 180ms ease-out,
-    clip-path 280ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.playback-artwork-visible {
-  clip-path: inset(0 round 0.25rem);
-  opacity: 1;
-  transition-delay: 0ms, 70ms, 0ms;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .playback-icon-enter-active,
-  .playback-icon-leave-active,
+  .playback-icon-leave-active {
+    transition: none;
+  }
+
   .playback-artwork {
     transition: none;
   }

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -101,11 +101,11 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group relative flex h-9 min-w-0 shrink items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          class="btn btn-icon group relative flex min-w-0 shrink items-center overflow-hidden text-left transition-[transform,width,padding,gap,border-color,background-color,box-shadow,filter] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           :class="
             live.spotifyAudioPlaying
-              ? 'w-9 justify-center rounded-md border border-transparent bg-transparent p-0 shadow-none sm:min-w-36 sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
-              : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent'
+              ? 'w-9 justify-center p-0 sm:min-w-36 sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
+              : 'w-9 justify-center p-0'
           "
           :disabled="live.spotifyAudioStatus === 'loading'"
           :aria-label="
@@ -122,7 +122,7 @@ function togglePlayback() {
             class="shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out-quint"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-9 translate-x-0 opacity-100 delay-75 sm:w-7'
+                ? 'w-7 translate-x-0 opacity-100 delay-75'
                 : 'w-0 -translate-x-1 opacity-0'
             "
             aria-hidden="true"
@@ -131,9 +131,9 @@ function togglePlayback() {
               v-if="artwork"
               :src="artwork"
               alt=""
-              class="size-9 rounded-md object-cover shadow-sm sm:size-7 sm:rounded-[4px]"
+              class="size-7 rounded-[4px] object-cover shadow-sm"
             />
-            <span v-else class="block size-9 rounded-md bg-paper sm:size-7 sm:rounded-[4px]" />
+            <span v-else class="block size-7 rounded-[4px] bg-paper" />
           </span>
           <span
             class="hidden min-w-0 transition-[width,opacity,transform] duration-200 ease-out-quint sm:block"

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,7 +119,7 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="playback-artwork shrink-0 overflow-hidden transition-[opacity,filter] duration-500 ease-out-quint md:transition-[width,opacity,transform,filter] md:duration-200"
+            class="playback-artwork shrink-0 overflow-hidden transition-[opacity,filter] duration-[5000ms] ease-out-quint md:transition-[width,opacity,transform,filter] md:duration-[2000ms]"
             :class="
               live.spotifyAudioPlaying
                 ? 'w-9 opacity-100 blur-0 md:w-7 md:translate-x-0'

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -136,11 +136,11 @@ function togglePlayback() {
             <span v-else class="block size-9 bg-paper sm:size-7 sm:rounded-[4px]" />
           </span>
           <span
-            class="hidden min-w-0 transition-[width,opacity,transform] duration-200 ease-out-quint sm:block"
+            class="playback-labels hidden min-w-0 transition-[width,opacity,transform,filter] duration-[2000ms] ease-out-quint sm:block"
             :class="
               live.spotifyAudioPlaying
-                ? 'flex-1 translate-x-0 opacity-100 delay-100'
-                : 'pointer-events-none w-0 flex-none translate-x-1 opacity-0'
+                ? 'flex-1 translate-x-0 opacity-100 blur-0 delay-100'
+                : 'pointer-events-none w-0 flex-none translate-x-1 opacity-0 blur-[2px]'
             "
           >
             <span class="block truncate text-xs font-medium">{{ track.name }}</span>
@@ -239,6 +239,10 @@ function togglePlayback() {
   }
 
   .playback-artwork {
+    transition: none;
+  }
+
+  .playback-labels {
     transition: none;
   }
 }

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,11 +119,11 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-200 ease-out-quint"
+            class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-300 ease-out-quint sm:duration-200"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-9 scale-100 opacity-100 blur-0 delay-75 sm:w-7 sm:translate-x-0'
-                : 'w-0 scale-75 opacity-0 blur-[2px] sm:-translate-x-1 sm:scale-100 sm:blur-0'
+                ? 'w-9 scale-100 opacity-100 blur-0 delay-100 sm:w-7 sm:translate-x-0'
+                : 'w-0 scale-90 opacity-0 blur-[6px] sm:-translate-x-1 sm:scale-100 sm:blur-0'
             "
             aria-hidden="true"
           >

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -77,7 +77,7 @@ function togglePlayback() {
         <span class="title hidden text-[0.95rem] sm:block">{{ site.name }}</span>
       </RouterLink>
 
-      <div class="flex items-center gap-1.5">
+      <div class="flex min-w-0 items-center gap-1.5">
         <LayoutGroup>
           <nav class="mr-1 hidden items-center md:flex">
             <RouterLink
@@ -101,10 +101,10 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group relative flex h-9 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          class="group relative flex h-9 min-w-0 shrink items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           :class="
             live.spotifyAudioPlaying
-              ? 'w-9 justify-center rounded-md border border-transparent bg-transparent p-0 shadow-none sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
+              ? 'w-9 justify-center rounded-md border border-transparent bg-transparent p-0 shadow-none sm:min-w-36 sm:w-56 sm:justify-start sm:gap-2 sm:rounded-lg sm:border-rule sm:bg-paper-sunk/60 sm:py-1 sm:pl-1 sm:pr-2 sm:shadow-sm sm:hover:border-accent'
               : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent'
           "
           :disabled="live.spotifyAudioStatus === 'loading'"

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useWindowScroll } from '@vueuse/core'
 import { Motion, LayoutGroup } from 'motion-v'
@@ -14,10 +14,11 @@ import {
   DialogTrigger,
   VisuallyHidden,
 } from 'reka-ui'
-import { Menu, X } from '@lucide/vue'
+import { Menu, Volume2, VolumeX, X } from '@lucide/vue'
 import ThemeToggle from './ThemeToggle.vue'
 import { ease } from '@/lib/motion'
 import { site } from '@/data/site'
+import { useLiveStore } from '@/stores/live'
 
 const nav = [
   { name: 'projects', label: 'Projects' },
@@ -29,12 +30,25 @@ const nav = [
 const route = useRoute()
 const { y } = useWindowScroll()
 const menuOpen = ref(false)
+const live = useLiveStore()
+const playing = computed(() => Boolean(live.spotify?.is_playing && live.spotify.item))
+const track = computed(() => live.spotify?.item)
+const artwork = computed(() => {
+  const images = track.value?.album.images ?? []
+  return images[images.length - 2]?.url ?? images[0]?.url
+})
+
+onMounted(() => void live.fetchSpotify())
 
 watch(() => route.fullPath, () => (menuOpen.value = false))
 
 function isActive(name: string) {
   // Detail pages keep their parent lit.
   return route.name === name || (name === 'projects' && route.name === 'project')
+}
+
+function togglePlayback() {
+  live.toggleSpotifyAudio(live.spotify?.progress_ms ?? 0)
 }
 </script>
 
@@ -83,6 +97,29 @@ function isActive(name: string) {
             </RouterLink>
           </nav>
         </LayoutGroup>
+
+        <button
+          v-if="playing && track"
+          type="button"
+          class="group flex h-9 max-w-44 items-center gap-2 rounded-lg border border-rule bg-paper-sunk/60 py-1 pl-1 pr-2 text-left shadow-sm transition-colors hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent sm:max-w-56"
+          :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
+          :aria-pressed="live.spotifyAudioPlaying"
+          @click="togglePlayback"
+        >
+          <img
+            v-if="artwork"
+            :src="artwork"
+            alt=""
+            class="size-7 shrink-0 rounded-[4px] object-cover shadow-sm"
+          />
+          <span v-else class="size-7 shrink-0 rounded-[4px] bg-paper" aria-hidden="true" />
+          <span class="hidden min-w-0 flex-1 sm:block">
+            <span class="block truncate text-xs font-medium">{{ track.name }}</span>
+            <span class="block truncate text-[0.65rem] text-ink-3">{{ track.artists[0]?.name }}</span>
+          </span>
+          <Volume2 v-if="live.spotifyAudioPlaying" class="size-3.5 shrink-0 text-accent" />
+          <VolumeX v-else class="size-3.5 shrink-0 text-ink-3 group-hover:text-accent" />
+        </button>
 
         <ThemeToggle />
 

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,11 +119,11 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-500 ease-out-quint sm:duration-200"
+            class="playback-artwork shrink-0 overflow-hidden transition-[opacity,filter] duration-500 ease-out-quint md:transition-[width,opacity,transform,filter] md:duration-200"
             :class="
               live.spotifyAudioPlaying
                 ? 'w-9 opacity-100 blur-0 md:w-7 md:translate-x-0'
-                : 'w-0 opacity-0 blur-[10px] md:-translate-x-1 md:blur-0'
+                : 'w-9 opacity-0 blur-[10px] md:w-0 md:-translate-x-1 md:blur-0'
             "
             aria-hidden="true"
           >

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -101,11 +101,11 @@ function togglePlayback() {
         <button
           v-if="playing && track"
           type="button"
-          class="group flex h-9 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          class="group flex h-9 shrink-0 items-center overflow-hidden text-left transition-[width,padding,gap,border-color,background-color,box-shadow] duration-300 ease-out-quint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           :class="
             live.spotifyAudioPlaying
               ? 'w-44 gap-2 rounded-lg border border-rule bg-paper-sunk/60 py-1 pl-1 pr-2 shadow-sm hover:border-accent sm:w-56'
-              : 'w-9 justify-center border border-transparent bg-transparent p-0 shadow-none hover:border-transparent'
+              : 'w-9 justify-center rounded-lg border border-rule bg-paper-sunk/60 p-0 shadow-sm hover:border-accent sm:rounded-none sm:border-transparent sm:bg-transparent sm:shadow-none sm:hover:border-transparent'
           "
           :aria-label="live.spotifyAudioPlaying ? `Mute ${track.name}` : `Unmute ${track.name}`"
           :aria-pressed="live.spotifyAudioPlaying"

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -119,11 +119,11 @@ function togglePlayback() {
           @click="togglePlayback"
         >
           <span
-            class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-300 ease-out-quint sm:duration-200"
+            class="playback-artwork shrink-0 overflow-hidden transition-[width,opacity,transform,filter] duration-500 ease-out-quint sm:duration-200"
             :class="
               live.spotifyAudioPlaying
-                ? 'w-9 scale-100 opacity-100 blur-0 delay-100 sm:w-7 sm:translate-x-0'
-                : 'w-0 scale-90 opacity-0 blur-[6px] sm:-translate-x-1 sm:scale-100 sm:blur-0'
+                ? 'w-9 opacity-100 blur-0 sm:w-7 sm:translate-x-0'
+                : 'w-0 opacity-0 blur-[10px] sm:-translate-x-1 sm:blur-0'
             "
             aria-hidden="true"
           >

--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useIntervalFn } from '@vueuse/core'
 import { LoaderCircle, VolumeX } from '@lucide/vue'
 import InlineIcon from '@/components/ui/InlineIcon.vue'
@@ -24,7 +24,6 @@ watch(
 )
 
 onMounted(() => void live.fetchSpotify())
-onBeforeUnmount(() => live.stopSpotifyPolling())
 
 const track = computed(() => live.spotify?.item)
 const playing = computed(() => Boolean(live.spotify?.is_playing))

--- a/client/src/stores/live.ts
+++ b/client/src/stores/live.ts
@@ -218,6 +218,17 @@ export const useLiveStore = defineStore('live', () => {
     discardPreloadedSpotifyAudio()
   }
 
+  /** Mute preserves the warmed stream and its buffer; unmute is immediate. */
+  function toggleSpotifyAudio(progressMs: number) {
+    if (spotifyAudioPlaying.value && spotifyAudio) {
+      spotifyAudio.muted = true
+      spotifyAudioPlaying.value = false
+      spotifyAudioStatus.value = 'idle'
+      return
+    }
+    return startSpotifyAudio(progressMs)
+  }
+
   watch(
     () => spotify.value?.item.id,
     (id, previous) => {
@@ -246,7 +257,7 @@ export const useLiveStore = defineStore('live', () => {
   watch(
     () => spotify.value?.is_playing,
     (isPlaying) => {
-      if (spotifyAudioPlaying.value && !isPlaying) stopSpotifyAudio()
+      if (spotifyAudio && !isPlaying) stopSpotifyAudio()
     },
   )
 
@@ -278,6 +289,9 @@ export const useLiveStore = defineStore('live', () => {
    */
   function fetchSpotify() {
     if (!BACKEND_URL) return
+    // The persistent header owns the connection; cards can safely ask for it
+    // too without multiplying SSE sockets or visibility listeners.
+    if (stream || polling) return
     if (typeof EventSource === 'undefined') return void pollSpotify()
 
     openStream()
@@ -476,6 +490,7 @@ export const useLiveStore = defineStore('live', () => {
     spotifyAudioPlaying,
     startSpotifyAudio,
     stopSpotifyAudio,
+    toggleSpotifyAudio,
     listening,
     listeningStatus,
     fetchListening,


### PR DESCRIPTION
## What changed

Refines the persistent live playback control in the site header.

- Adds an icon-only muted state and a loading indicator while the stream connects.
- Makes the mobile control a full-bleed album-art button with a centered volume overlay.
- Lets the desktop control shrink and truncate metadata in tighter toolbars.
- Adds responsive artwork and metadata transitions, with reduced-motion support.

## Why

The live player needs to remain compact, legible, and usable across navigation and viewport sizes without obscuring adjacent toolbar controls.

## Validation

- `npm run typecheck`
