### PR TITLE
Keep live playback synchronized during startup

### DIFF
--- a/client/src/components/social/NowPlaying.vue
+++ b/client/src/components/social/NowPlaying.vue
@@ -94,6 +94,7 @@ async function toggleAudio() {
       ]"
     >
       <button
+        v-if="playing"
         type="button"
         class="group relative shrink-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent disabled:cursor-default"
         :disabled="!streamUrl || live.spotifyAudioPlaying || live.spotifyAudioStatus === 'loading'"
@@ -136,6 +137,14 @@ async function toggleAudio() {
           <VolumeX v-else class="size-3.5" />
         </span>
       </button>
+      <RecordSleeve
+        v-else
+        :artwork="artwork"
+        :alt="`${track.name} album art`"
+        :size="compact ? 40 : 76"
+        :playing="false"
+        class="shrink-0"
+      />
 
       <div class="min-w-0 flex-1" :class="compact && 'text-right'">
         <a

--- a/client/src/stores/live.ts
+++ b/client/src/stores/live.ts
@@ -72,6 +72,10 @@ export const useLiveStore = defineStore('live', () => {
     // chunked response.
     const offset = Math.min(Math.max(0, progressMs), Math.max(0, item.duration_ms - 1))
     url.searchParams.set('startMs', String(Math.round(offset)))
+    // Jukebox advances the source by the time it spent resolving and starting
+    // the stream, so a warm muted stream begins near the live position rather
+    // than a few seconds behind it.
+    url.searchParams.set('requestedAtMs', String(Date.now()))
     return url.href
   }
 


### PR DESCRIPTION
## What changed

- Compensates Jukebox stream offsets for the time spent resolving and starting a stream.
- Sends the request timestamp from the website for both muted prebuffering and direct playback.
- Hides the now-playing unmute control when Spotify playback is paused.

## Why

Live audio could begin a few seconds behind Spotify when source startup took time. Jukebox now advances the requested offset before launching the stream, without adding another buffering round trip.

## Validation

- Website: `npm run typecheck`
- Jukebox: `npm test`
