### PR TITLE
Serve prerendered pages on the self-hosted image

### DIFF
--- a/client/src/data/posts.ts
+++ b/client/src/data/posts.ts
@@ -78,9 +78,9 @@ export const posts: Post[] = Object.entries(modules)
   .map(([path, module]) => toPost(path, module))
   .filter((post) => import.meta.env.DEV || !post.draft)
   // Newest first. Entries published on the same day fall back to their part
-  // number, so a series posted in one go still reads from the beginning rather
-  // than in whatever order the filenames happen to sort.
-  .sort((a, b) => b.date.getTime() - a.date.getTime() || (a.part ?? 0) - (b.part ?? 0))
+  // number, latest part first, so the index stays reverse chronological
+  // throughout rather than flipping order inside a series.
+  .sort((a, b) => b.date.getTime() - a.date.getTime() || (b.part ?? 0) - (a.part ?? 0))
 
 export function findPost(slug: string): Post | undefined {
   return posts.find((post) => post.slug === slug)

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -47,9 +47,30 @@ if (production) {
   app.use('/api', routes)
   app.use('/api', (req, res) => res.status(404).json({ message: 'Not found.' }))
 
-  app.use(express.static(clientDist, { index: false, maxAge: '1h' }))
-  // Vue Router owns all non-API paths after the first page load.
-  app.get('{*path}', (req, res) => res.sendFile(path.join(clientDist, 'index.html')))
+  // `redirect: false` so a prerendered route is not bounced to a trailing
+  // slash before the handler below can serve it.
+  app.use(express.static(clientDist, { index: false, redirect: false, maxAge: '1h' }))
+  /**
+   * Vue Router owns all non-API paths after the first page load, but the build
+   * prerenders most routes to `<route>/index.html`. Serving that file when it
+   * exists is what makes the prose and the per-page `og:` tags reachable by a
+   * crawler; falling straight through to the SPA shell would hand every route
+   * the same generic title and an empty body.
+   *
+   * Routes that are only rendered in the browser, `/guestbook` among them, have
+   * no prerendered file and still get the shell.
+   */
+  app.get('{*path}', (req, res) => {
+    const prerendered = path.join(clientDist, req.path, 'index.html')
+    // `req.path` is attacker-controlled, so confirm the resolved file is still
+    // inside the build before handing it over.
+    if (path.resolve(prerendered).startsWith(clientDist + path.sep)) {
+      return res.sendFile(prerendered, (error) => {
+        if (error) res.sendFile(path.join(clientDist, 'index.html'))
+      })
+    }
+    res.sendFile(path.join(clientDist, 'index.html'))
+  })
 } else {
   // Local development keeps the original root-level API paths, so the Vite
   // client and existing tests can continue talking to http://localhost:3001.


### PR DESCRIPTION
Follow-up to #62, found while deploying it.

## The bug

`vite-ssg` writes each route to `<route>/index.html`, but the server ran `express.static` with `index: false` and then sent the SPA shell from the catch-all. So on vega:

```
alex.wohlbruck.com/blog/where-parchment-started  →  <title>Where Parchment started · Alex Wohlbruck</title>
alex.wohlbruck.dev/blog/where-parchment-started  →  <title>Alex Wohlbruck · Software engineer & designer</title>
```

Netlify resolves directory indexes on its own, so it was fine. The self-hosted image returned an empty body and identical `og:` tags on every URL — prerendering doing nothing on the host where it was most load-bearing.

## The fix

The catch-all checks for `<path>/index.html` before falling back to the shell, with a path-traversal guard since `req.path` is attacker-controlled. `redirect: false` on `express.static` stops it bouncing directory requests to a trailing slash first, which keeps URLs clean.

Verified against a production-mode server with the real build:

| Route | Result |
|---|---|
| `/blog/where-parchment-started` | prerendered page, correct `og:title`, prose present |
| `/projects/parchment` | prerendered page |
| `/` | prerendered home |
| `/guestbook` | SPA shell, as intended — no prerendered file |
| `/nope/nothing` | SPA shell, client renders 404 |
| `/api/nope` | still JSON 404 |
| `/feed.xml` | 200 |

94 server tests pass.

## Also

Same-day posts now sort by descending part, so the blog index is reverse chronological throughout rather than flipping order inside a series.