### PR TITLE
List the newest posts on the home page

### DIFF
--- a/client/src/components/post/PostRow.vue
+++ b/client/src/components/post/PostRow.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ArrowUpRight } from '@lucide/vue'
+import { postDate, type Post } from '@/data/posts'
+
+withDefaults(
+  defineProps<{
+    post: Post
+    /** Tighter row, for lists that sit inside another page's section. */
+    compact?: boolean
+    /** Heading level, so each list stays inside its page's outline. */
+    heading?: string
+    /** Off where the surrounding page already names the run. */
+    showSeries?: boolean
+  }>(),
+  { compact: false, heading: 'h2', showSeries: true },
+)
+</script>
+
+<template>
+  <RouterLink
+    :to="{ name: 'post', params: { slug: post.slug } }"
+    class="group flex flex-col border-b border-rule md:flex-row md:items-baseline md:gap-8"
+    :class="compact ? 'gap-1 py-5' : 'gap-2 py-7'"
+  >
+    <time
+      :datetime="post.date.toISOString().slice(0, 10)"
+      class="label shrink-0 text-ink-3 md:w-32 md:pt-1"
+    >
+      {{ postDate(post.date) }}
+    </time>
+
+    <div class="min-w-0 flex-1">
+      <!-- Entries in a run say so here rather than being grouped, so a list
+           stays in date order however it is filtered. -->
+      <p v-if="showSeries && post.series" class="label mb-1.5 text-accent">
+        {{ post.series }}
+        <template v-if="post.part"> · Part {{ post.part }}</template>
+      </p>
+
+      <component
+        :is="heading"
+        class="title flex items-start gap-2 transition-colors group-hover:text-accent"
+        :class="compact ? 'text-xl' : 'text-2xl'"
+      >
+        <span class="min-w-0">{{ post.title }}</span>
+        <!-- Drafts are only ever rendered by a dev build. -->
+        <span v-if="post.draft" class="chip mt-1 shrink-0">Draft</span>
+        <ArrowUpRight
+          class="size-4 shrink-0 text-ink-3 transition-transform duration-300 ease-out-quint group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+          :class="compact ? 'mt-1' : 'mt-1.5'"
+        />
+      </component>
+
+      <p
+        v-if="post.summary"
+        class="max-w-2xl text-sm text-ink-3"
+        :class="compact ? 'mt-1.5' : 'mt-2'"
+      >
+        {{ post.summary }}
+      </p>
+    </div>
+  </RouterLink>
+</template>

--- a/client/src/data/posts.ts
+++ b/client/src/data/posts.ts
@@ -82,6 +82,11 @@ export const posts: Post[] = Object.entries(modules)
   // throughout rather than flipping order inside a series.
   .sort((a, b) => b.date.getTime() - a.date.getTime() || (b.part ?? 0) - (a.part ?? 0))
 
+/** The newest few, for the home page's writing list. */
+export function recentPosts(count: number): Post[] {
+  return posts.slice(0, count)
+}
+
 export function findPost(slug: string): Post | undefined {
   return posts.find((post) => post.slug === slug)
 }

--- a/client/src/views/BlogView.vue
+++ b/client/src/views/BlogView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { AnimatePresence, Motion } from 'motion-v'
-import { ArrowUpRight } from '@lucide/vue'
 import PageHeader from '@/components/layout/PageHeader.vue'
-import { posts, postDate, postTagLabel, postTags } from '@/data/posts'
+import PostRow from '@/components/post/PostRow.vue'
+import { posts, postTagLabel, postTags } from '@/data/posts'
 import { duration, ease, step } from '@/lib/motion'
 
 const active = ref<string | null>(null)
@@ -58,37 +58,7 @@ function toggle(tag: string) {
           :exit="{ opacity: 0, filter: 'blur(4px)' }"
           :transition="{ duration: duration.base, ease, delay: step(Math.min(index, 8)) }"
         >
-          <RouterLink
-            :to="{ name: 'post', params: { slug: post.slug } }"
-            class="group flex flex-col gap-2 border-b border-rule py-7 md:flex-row md:items-baseline md:gap-8"
-          >
-            <time
-              :datetime="post.date.toISOString().slice(0, 10)"
-              class="label shrink-0 text-ink-3 md:w-32 md:pt-1"
-            >
-              {{ postDate(post.date) }}
-            </time>
-
-            <div class="min-w-0 flex-1">
-              <!-- Entries in a run say so here rather than being grouped, so
-                   the index stays one list in date order however it is filtered. -->
-              <p v-if="post.series" class="label mb-1.5 text-accent">
-                {{ post.series }}
-                <template v-if="post.part"> · Part {{ post.part }}</template>
-              </p>
-              <h2 class="title flex items-start gap-2 text-2xl transition-colors group-hover:text-accent">
-                <span class="min-w-0">{{ post.title }}</span>
-                <!-- Drafts are only ever rendered by a dev build. -->
-                <span v-if="post.draft" class="chip mt-1 shrink-0">Draft</span>
-                <ArrowUpRight
-                  class="mt-1.5 size-4 shrink-0 text-ink-3 transition-transform duration-300 ease-out-quint group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                />
-              </h2>
-              <p v-if="post.summary" class="mt-2 max-w-2xl text-sm text-ink-3">
-                {{ post.summary }}
-              </p>
-            </div>
-          </RouterLink>
+          <PostRow :post="post" />
         </Motion>
       </AnimatePresence>
     </ol>

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -12,12 +12,15 @@ import ProjectMini from '@/components/project/ProjectMini.vue'
 import RotatingWord from '@/components/home/RotatingWord.vue'
 import IndexCard from '@/components/home/IndexCard.vue'
 import LivePreviews from '@/components/home/LivePreviews.vue'
+import PostRow from '@/components/post/PostRow.vue'
 import { featuredProjects, moreProjects, projects } from '@/data/projects'
+import { posts, recentPosts } from '@/data/posts'
 import { site } from '@/data/site'
 import { duration, ease, inView, step } from '@/lib/motion'
 
 const featured = featuredProjects
 const alsoRan = moreProjects(4)
+const recent = recentPosts(3)
 
 const enter = (delay: number) => ({
   initial: { opacity: 0, y: 14, filter: 'blur(4px)' },
@@ -126,6 +129,36 @@ function leanWash(event: PointerEvent) {
       <div class="mt-10 flex justify-center">
         <AppButton :to="{ name: 'projects' }" variant="ghost" class="nudge">
           See all {{ projects.length }} projects
+          <ArrowRight class="size-4" />
+        </AppButton>
+      </div>
+    </section>
+
+    <!-- Recent writing ------------------------------------------------------>
+    <section v-if="recent.length" class="py-16">
+      <SectionHeading
+        title="Recent writings"
+        note="Dev logs, ideas, and shower thoughts that I felt like writing down."
+      />
+
+      <ol>
+        <Motion
+          v-for="(post, index) in recent"
+          :key="post.slug"
+          as="li"
+          :initial="{ opacity: 0, y: 14, filter: 'blur(4px)' }"
+          :while-in-view="{ opacity: 1, y: 0, filter: 'blur(0px)' }"
+          :in-view-options="inView"
+          :transition="{ duration: duration.base, ease, delay: step(index) }"
+        >
+          <PostRow :post="post" compact heading="h3" />
+        </Motion>
+      </ol>
+
+      <!-- Nothing to go and see if the list already holds everything. -->
+      <div v-if="posts.length > recent.length" class="mt-10 flex justify-center">
+        <AppButton :to="{ name: 'blog' }" variant="ghost" class="nudge">
+          Read all {{ posts.length }} posts
           <ArrowRight class="size-4" />
         </AppButton>
       </div>

--- a/client/src/views/ProjectView.vue
+++ b/client/src/views/ProjectView.vue
@@ -7,6 +7,7 @@ import AppButton from '@/components/ui/AppButton.vue'
 import InlineIcon from '@/components/ui/InlineIcon.vue'
 import ProjectTile from '@/components/project/ProjectTile.vue'
 import ProjectGallery from '@/components/project/ProjectGallery.vue'
+import PostRow from '@/components/post/PostRow.vue'
 import RichText from '@/components/ui/RichText.vue'
 import NotFoundView from './NotFoundView.vue'
 import { adjacentProjects, findProject, projectBody } from '@/data/projects'
@@ -190,13 +191,20 @@ const enter = (delay: number) => ({
 
       <ol>
         <li v-for="row in visibleWriting" :key="row.key">
-          <!-- A series opens at its first entry, which is the way in to the
-               run. A standalone post opens itself. -->
+          <!-- Every row on this page belongs to this project, so a post names
+               itself rather than the run it happens to sit in. -->
+          <PostRow
+            v-if="row.kind === 'post'"
+            :post="row.post"
+            compact
+            heading="h3"
+            :show-series="false"
+          />
+
+          <!-- A series opens at its first entry, which is the way in to the run. -->
           <RouterLink
-            :to="{
-              name: 'post',
-              params: { slug: row.kind === 'series' ? row.start.slug : row.post.slug },
-            }"
+            v-else
+            :to="{ name: 'post', params: { slug: row.start.slug } }"
             class="group flex flex-col gap-1 border-b border-rule py-5 md:flex-row md:items-baseline md:gap-8"
           >
             <time
@@ -206,7 +214,7 @@ const enter = (delay: number) => ({
               {{ postDate(row.updated) }}
             </time>
 
-            <span v-if="row.kind === 'series'" class="min-w-0 flex-1">
+            <span class="min-w-0 flex-1">
               <span class="label mb-1 block text-accent">Series</span>
               <span class="title flex items-start gap-2 text-xl transition-colors group-hover:text-accent">
                 <span class="min-w-0">{{ row.series }}</span>
@@ -219,19 +227,6 @@ const enter = (delay: number) => ({
               </span>
               <span v-if="row.start.summary" class="mt-1.5 block max-w-2xl text-sm text-ink-3">
                 {{ row.start.summary }}
-              </span>
-            </span>
-
-            <span v-else class="min-w-0 flex-1">
-              <span class="title flex items-start gap-2 text-xl transition-colors group-hover:text-accent">
-                <span class="min-w-0">{{ row.post.title }}</span>
-                <span v-if="row.post.draft" class="chip mt-1 shrink-0">Draft</span>
-                <ArrowUpRight
-                  class="mt-1 size-4 shrink-0 text-ink-3 transition-transform duration-300 ease-out-quint group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                />
-              </span>
-              <span v-if="row.post.summary" class="mt-1.5 block max-w-2xl text-sm text-ink-3">
-                {{ row.post.summary }}
               </span>
             </span>
           </RouterLink>


### PR DESCRIPTION
Adds a **Recent writings** section to the landing page, between the projects grid and the closing note: the three newest posts, plus a ghost button through to `/blog` (hidden when the list already shows everything).

There was no shared list component to reuse — the row was written inline twice, in the blog index and in a project page's writing list — so this extracts one and uses it in all three places.

### Changes
- **New** `components/post/PostRow.vue` — dateline, series label, title with the hover arrow, summary. Props: `compact` for density, `heading` so each list stays inside its page's outline, `showSeries`.
- **New** `recentPosts(n)` in `data/posts.ts`, alongside the existing `moreProjects(n)`.
- `BlogView` and `ProjectView` now render `PostRow`. The project page passes `:show-series="false"`, keeping its behaviour of naming the post rather than the run it belongs to — every row there is already about that project. Its series rows keep their own markup, being a different shape.

### Verified
`vue-tsc` clean, and a full `vite-ssg` build prerenders all three rows and their links into `dist/index.html`; project writing lists still render.